### PR TITLE
remove redundant `ensure_trafaret` call in `Dict` trafaret

### DIFF
--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -950,7 +950,7 @@ class Dict(Trafaret, DictAsyncMixin):
         self.keys = list(args)
         for key, trafaret in itertools.chain(trafarets.items(), keys.items()):
             key_ = Key(key) if isinstance(key, str_types) else key
-            key_.set_trafaret(ensure_trafaret(trafaret))
+            key_.set_trafaret(trafaret)
             self.keys.append(key_)
 
     def allow_extra(self, *names, **kw):


### PR DESCRIPTION
there is no need to call `ensure_trafaret` in `Dict` [trafaret](https://github.com/Deepwalker/trafaret/blob/master/trafaret/base.py#L953), because it is called in `Key` [trafaret](https://github.com/Deepwalker/trafaret/blob/master/trafaret/base.py#L866)