### PR TITLE
trafaret call prior to trafaret check

### DIFF
--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -1365,10 +1365,10 @@ def catch(checker, *a, **kw):
     """
 
     try:
-        if hasattr(checker, 'check'):
-            return checker.check(*a, **kw)
-        elif callable(checker):
+        if callable(checker):
             return checker(*a, **kw)
+        elif hasattr(checker, 'check'):
+            return checker.check(*a, **kw)
     except DataError as error:
         return error
 


### PR DESCRIPTION
In previous [PR](https://github.com/Deepwalker/trafaret/pull/3), there were changes that inner trafarets are called rather than `check`ed.  But I forgot to make changes in one more place: function catch. Sorry, it's my fault