### PR TITLE
Fix call ensure_trafaret in OnError trafaret

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -738,6 +738,29 @@ class TestDataError(unittest.TestCase):
         )
 
 
+class TestOnErrorTrafaret(unittest.TestCase):
+    def test_on_error(self):
+        trafaret = t.OnError(t.Bool(), message='Changed message')
+
+        res = trafaret(True)
+
+        self.assertEqual(res, True)
+
+    def test_on_error_ensured_trafaret(self):
+        trafaret = t.OnError(t.Bool, message='Changed message')
+
+        res = trafaret(False)
+
+        self.assertEqual(res, False)
+
+    def test_on_error_data_error(self):
+        trafaret = t.OnError(t.Bool, message='Changed message')
+
+        res = catch_error(trafaret, 'Trololo')
+
+        self.assertEqual(res.as_dict(), 'Changed message')
+
+
 # res = @guard(a=String, b=Int, c=String)
 #     def fn(a, b, c="default"):
 #         '''docstring'''

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -158,7 +158,7 @@ class Trafaret(TrafaretAsyncMixin):
 
 class OnError(Trafaret):
     def __init__(self, trafaret, message):
-        self.trafaret = trafaret
+        self.trafaret = ensure_trafaret(trafaret)
         self.message = message
 
     def transform(self, value, context=None):


### PR DESCRIPTION
OnError trafaret works incorrectly. Because "ensure_trafaret" call is missed. So, if we write something like this:
```python
import trafaret as t


trafaret = t.OnError(t.Bool(), 'Changed message')

res = trafaret(True)
```

it will work correctly. But if we write something like this:

```python
import trafaret as t


trafaret = t.OnError(t.Bool, 'Changed message')

res = trafaret(True)
```

we will have TypeError.

