### PR TITLE
Fix import issue for DeepKey

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,6 +4,7 @@ import trafaret as t
 from collections import Mapping as AbcMapping
 from trafaret import catch_error, extract_error, DataError
 from trafaret.extras import KeysSubset
+from trafaret.visitor import DeepKey
 
 
 class TestAnyTrafaret(unittest.TestCase):
@@ -850,3 +851,14 @@ class TestOnErrorTrafaret(unittest.TestCase):
 # self.assertEqual(res, {'B.a': DataError(Unexistent key)}
 # res = dict(DeepKey('c.B.d.a', to_name='B_a', trafaret=Int()).pop({'c': A}))
 # self.assertEqual(res, {'B_a': DataError(value can't be converted to int)}
+
+
+class TestDeepKey(unittest.TestCase):
+
+    def test_fetch_value_by_path(self):
+        class A(object):
+            class B(object):
+                d = {'a': 'word'}
+
+        res = dict((DeepKey('B.d.a') >> 'B_a').pop(A))
+        self.assertEqual(res, {'B_a': 'word'})

--- a/trafaret/visitor.py
+++ b/trafaret/visitor.py
@@ -3,7 +3,8 @@ This module is expirement. API and implementation are unstable.
 Supposed to use with ``Request`` object or something like that.
 """
 from collections import Mapping
-from . import Trafaret, DataError, Key, catch_error, _empty
+from . import Trafaret, DataError, Key, catch_error
+from .lib import _empty
 
 
 def get_deep_attr(obj, keys):


### PR DESCRIPTION
When I tried to use `DeepKey` and got an exception `ImportError`

```
In [5]: from trafaret.visitor import DeepKey
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-5-95d295fba11c> in <module>()
----> 1 from trafaret.visitor import DeepKey

~/.virtualenvs/looker-api/lib/python3.6/site-packages/trafaret/visitor.py in <module>()
      4 """
      5 from collections import Mapping
----> 6 from . import Trafaret, DataError, Key, catch_error, _empty
      7
      8

ImportError: cannot import name '_empty'
```

This pull request:
 - fix issue with `ImportError`
 - cover the fix with a basic test for `DeepKey`, with an example from docs