### PR TITLE
Add 'off' value support to StrBool trafaret

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -505,6 +505,10 @@ class TestStrBoolTrafaret(unittest.TestCase):
         self.assertEqual(res, True)
         res = t.StrBool().check(False)
         self.assertEqual(res, False)
+        res = t.StrBool().check('on')
+        self.assertEqual(res, True)
+        res = t.StrBool().check('off')
+        self.assertEqual(res, False)
 
 
 

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -380,7 +380,7 @@ class StrBool(Trafaret):
     False
     """
 
-    convertable = ('t', 'true', 'false', 'y', 'n', 'yes', 'no', 'on',
+    convertable = ('t', 'true', 'false', 'y', 'n', 'yes', 'no', 'on', 'off',
                    '1', '0', 'none')
 
     def check_and_return(self, value):


### PR DESCRIPTION
StrBool trafaret supports various ways to specify boolean by means of
string. It does support 'on' since very beginning by some mistake it
does not support its inverse value - 'off' - which might be very
convenient in some cases like using Trafaret to validate and convert
values retrieved from some INI file.