### PR TITLE
Fix README "Rename dict keys" example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Rename dict keys:
 
 .. code-block:: python
 
-    >>> c = t.Dict(t.Key('uNJ') >> 'user_name': t.String})
+    >>> c = t.Dict({(t.Key('uNJ') >> 'user_name'): t.String})
     >>> c.check({'uNJ': 'Adam'})
     {'user_name': 'Adam'}
 


### PR DESCRIPTION
* Add missing curly bracket at validator construction
* Add round brackets to improve readability of t.Dict's key