### PR TITLE
Extension with zero sign for StrBool

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -482,6 +482,8 @@ class TestStrBoolTrafaret(unittest.TestCase):
         self.assertEqual(res, True)
         res = t.StrBool().check('n')
         self.assertEqual(res, False)
+        res = t.StrBool().check('z')
+        self.assertEqual(res, False)
         res = t.StrBool().check(None)
         self.assertEqual(res, False)
         res = t.StrBool().check('1')
@@ -500,7 +502,6 @@ class TestStrBoolTrafaret(unittest.TestCase):
         self.assertEqual(res, True)
         res = t.StrBool().check('off')
         self.assertEqual(res, False)
-
 
 
 class TestStringTrafaret(unittest.TestCase):

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -361,6 +361,8 @@ class StrBool(Trafaret):
     True
     >>> StrBool().check('n')
     False
+    >>> StrBool().check('z')
+    False
     >>> StrBool().check(None)
     False
     >>> StrBool().check('1')
@@ -377,7 +379,7 @@ class StrBool(Trafaret):
     False
     """
 
-    convertable = ('t', 'true', 'false', 'y', 'n', 'yes', 'no', 'on', 'off',
+    convertable = ('t', 'true', 'false', 'y', 'n', 'z', 'yes', 'no', 'on', 'off',
                    '1', '0', 'none')
 
     def check_and_return(self, value):


### PR DESCRIPTION
As with `N` or `Y` values some API's returns `Z` as False as well. Also in the original `StrBool` - `0` value exists, so here is the suggestion to extend `StrBool` Trafaret with `z` value. 