### PR TITLE
Support Getting Keys by Name and Checking Partial Dicts

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -201,6 +201,34 @@ class TestDictTrafaret(unittest.TestCase):
         dct = t.Dict(key1=t.String)
         dct + {'a': t.String}
 
+    def test_get(self):
+        trafaret = t.Dict({t.Key('foo'): t.String, 'bar': t.Int})
+        self.assertEqual('foo', trafaret.get('foo').name)
+        self.assertEqual(str(trafaret.get('bar')), str(t.Key('bar', trafaret=t.Int)))
+        with self.assertRaises(KeyError):
+            trafaret.get('baz')
+
+    def test_partial_check(self):
+        trafaret = t.Dict({
+            t.Key('foo'): t.Dict({
+                t.Key('bar'): t.String,
+                'buzz': t.Int
+            }),
+            'baz': t.Int,
+            'lak': t.String
+        })
+        value_1 = {
+            'foo': {
+                'bar': 'this is a string'
+            },
+            'baz': 123
+        }
+        self.assertEqual(trafaret.partial_check(value_1), value_1)
+
+        value_2 = {'baz': 'this should be an int'}
+        with self.assertRaises(t.DataError):
+            trafaret.partial_check(value_2)
+
     def test_mapping_interface(self):
         trafaret = t.Dict({t.Key("foo"): t.String, t.Key("bar"): t.Float})
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -207,6 +207,8 @@ class TestDictTrafaret(unittest.TestCase):
         self.assertEqual(str(trafaret.get('bar')), str(t.Key('bar', trafaret=t.Int)))
         with self.assertRaises(KeyError):
             trafaret.get('baz')
+        trafaret += t.Dict({'baz': t.String})
+        self.assertEqual('baz', trafaret.get('baz').name)
 
     def test_partial_check(self):
         trafaret = t.Dict({

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -939,7 +939,7 @@ class Dict(Trafaret, DictAsyncMixin):
         # optimized version without runtime check for context arg
         self._keys = [with_context_caller(key) for key in self.keys]
 
-        self.key_registry = {key.name: key for key in self.keys}
+        self.key_registry = {key.name: key for key in self.keys if isinstance(key, Key)}
 
     def _clone_args(self):
         """ return args to create new Dict clone
@@ -1024,6 +1024,7 @@ class Dict(Trafaret, DictAsyncMixin):
         """ Given the name of a Key, return the corresponding Key object.
 
         Note: Does not support to_name since mutliple Keys may have the same to_name.
+              Does not support arbitrary callables that aren't saved as Key objects.
 
         >>> Dict({t.Key('foo'): t.String}).get('foo')
         <Key "foo" <String>>
@@ -1082,11 +1083,10 @@ class Dict(Trafaret, DictAsyncMixin):
 
         for k, v in value.items():
             if isinstance(v, AbcMapping):
-
                 collect[k] = self.get(k).trafaret.partial_check(v, context=context)
             else:
                 collect[k] = self.get(k).trafaret.check(v, context=context)
-            return collect
+        return collect
 
     def __repr__(self):
         r = "<Dict("


### PR DESCRIPTION
Imagine that you have a Dict trafaret made up of many Key objects, each of which  have their own trafarets (which may be deeper-nested Dict trafarets). For example:
```
>>> validator = t.Dict({
            t.Key('foo'): t.Dict({
                t.Key('bar'): t.String,
                'buzz': t.Int
            }),
            'baz': t.Int,
            'lak': t.String
        })
````
Now imagine that you have a python dictionary that makes up a subset of the structure above, such as:
```
>>> partial = {
            'foo': {
                'bar': 'this is a string'
            },
            'baz': 123
        }
```

Now, you'd like to validate that everything within `partial` is valid against `validator` without creating a new trafaret and it's okay if it is not "complete".

This is where the new `partial_check` function can be used. It recurses through a python dictionary and validates that each key/value  present is valid against the trafaret, even if it might not fully make up the trafaret's complete structure.

One immediate use case is `PATCH` API endpoints, where a client offers a subset of key/value pairs that they'd like to update for an object and you'd like the server to validate the payload against the existing trafaret-based data model.

This new `partial_check` forced the creation of another helpful function: `get`. `get` allows you to pass the name of a `Key` object and return the corresponding `Key` object from within the `Dict`, throwing a `KeyValue` error if no `Key` by that name is present.