### PR TITLE
Fix for Python 3.8

### DIFF
--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -4,7 +4,7 @@ import functools
 import itertools
 import numbers
 import warnings
-from collections import Mapping as AbcMapping
+from collections.abc import Mapping as AbcMapping
 from .lib import (
     py3,
     py36,

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -4,7 +4,10 @@ import functools
 import itertools
 import numbers
 import warnings
-from collections.abc import Mapping as AbcMapping
+try:
+    from collections.abc import Mapping as AbcMapping
+except ImportError:
+    from collections import Mapping as AbcMapping
 from .lib import (
     py3,
     py36,


### PR DESCRIPTION
Python 3.7 shows warnings while trying to import ABC classes directly from `collections`:
```
/usr/local/lib/python3.7/site-packages/trafaret/base.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```