### PR TITLE
Rename StrBool to ToBool

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -402,10 +402,10 @@ The checker test that a received value is a boolean type.
     t.Bool().check(True)
     # True
 
-StrBool
-.......
+ToBool
+......
 
-If you need to check value that can be equivalent to a boolean type, you can use ``StrBool``.
+If you need to check value that can be equivalent to a boolean type, you can use ``ToBool``.
 **Letter case doesn't matter.**
 
 Sample with all supported equivalents:
@@ -416,7 +416,7 @@ Sample with all supported equivalents:
                     'false', 'n', 'no', 'off', '0', 'none')
 
     for value in equivalents:
-      print("%s is %s" % (value, t.StrBool().check(value)))
+      print("%s is %s" % (value, t.ToBool().check(value)))
 
     # t is True
     # true is True
@@ -435,13 +435,13 @@ Also, function can take ``1`` and ``0`` as integers, ``booleans`` and ``None``.
 
 .. code-block:: python
 
-    t.StrBool().check(1)
+    t.ToBool().check(1)
     # True
 
-    t.StrBool().check(False)
+    t.ToBool().check(False)
     # False
 
-    t.StrBool().check(None)
+    t.ToBool().check(None)
     # False
 
 Float

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -566,7 +566,7 @@ class TestAndTest:
         assert repr(t.Bool & t.Null) == '<And(<Bool>, <Null>)>'
 
 
-class TestStrBoolTrafaret:
+class TestToBoolTrafaret:
     @pytest.mark.parametrize('value, expected_result', [
         # True results
         ('t', True),
@@ -587,15 +587,15 @@ class TestStrBoolTrafaret:
         (False, False),
     ])
     def test_str_bool(self, value, expected_result):
-        actual_result = t.StrBool().check(value)
+        actual_result = t.ToBool().check(value)
         assert actual_result == expected_result
 
     def test_extract_error(self):
-        res = extract_error(t.StrBool(), 'aloha')
+        res = extract_error(t.ToBool(), 'aloha')
         assert res == "value can't be converted to Bool"
 
     def test_repr(self):
-        assert repr(t.StrBool()) == '<StrBool>'
+        assert repr(t.ToBool()) == '<ToBool>'
 
 
 class TestStringTrafaret:

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -25,7 +25,7 @@ from .base import (
     Type,
     Subclass,
     Mapping,
-    StrBool,
+    ToBool,
     DictKeys,
 
     guard,
@@ -87,7 +87,7 @@ __all__ = (
     "Type",
     "Subclass",
     "Mapping",
-    "StrBool",
+    "ToBool",
     "DictKeys",
 
     "guard",

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -357,31 +357,31 @@ class Bool(Trafaret):
         return "<Bool>"
 
 
-class StrBool(Trafaret):
+class ToBool(Trafaret):
     """
-    >>> extract_error(StrBool(), 'aloha')
+    >>> extract_error(ToBool(), 'aloha')
     "value can't be converted to Bool"
-    >>> StrBool().check(1)
+    >>> ToBool().check(1)
     True
-    >>> StrBool().check(0)
+    >>> ToBool().check(0)
     False
-    >>> StrBool().check('y')
+    >>> ToBool().check('y')
     True
-    >>> StrBool().check('n')
+    >>> ToBool().check('n')
     False
-    >>> StrBool().check(None)
+    >>> ToBool().check(None)
     False
-    >>> StrBool().check('1')
+    >>> ToBool().check('1')
     True
-    >>> StrBool().check('0')
+    >>> ToBool().check('0')
     False
-    >>> StrBool().check('YeS')
+    >>> ToBool().check('YeS')
     True
-    >>> StrBool().check('No')
+    >>> ToBool().check('No')
     False
-    >>> StrBool().check(True)
+    >>> ToBool().check(True)
     True
-    >>> StrBool().check(False)
+    >>> ToBool().check(False)
     False
     """
 
@@ -393,14 +393,14 @@ class StrBool(Trafaret):
         _value = str(value).strip().lower()
         if _value not in self.convertable:
             self._failure(
-                "value can't be converted to Bool",
+                'value can\'t be converted to Bool',
                 value=value,
                 code=codes.IS_NOT_CONVERTIBLE_TO_BOOL,
             )
         return _value in ('t', 'true', 'y', 'yes', 'on', '1')
 
     def __repr__(self):
-        return "<StrBool>"
+        return "<ToBool>"
 
 
 class Atom(Trafaret):


### PR DESCRIPTION
`StrBool` deals not only with yes, no and other string values, but also with integer values, so decided to have instead `StrBool` — `ToBool` trafaret.
The same for `Int`/`ToInt`, `Date`/`ToDate` etc trafarets.