### PR TITLE
Add '1.0' and '0.0' to `ToBool`

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -425,8 +425,8 @@ Sample with all supported equivalents:
 
 .. code-block:: python
 
-    equivalents  = ('t', 'true', 'y', 'yes', 'on', '1',\
-                    'false', 'n', 'no', 'off', '0', 'none')
+    equivalents  = ('t', 'true', 'y', 'yes', 'on', '1', '1.0',\
+                    'false', 'n', 'no', 'off', '0', '0.0', 'none')
 
     for value in equivalents:
       print("%s is %s" % (value, t.ToBool().check(value)))
@@ -437,11 +437,13 @@ Sample with all supported equivalents:
     # yes is True
     # on is True
     # 1 is True
+    # 1.0 is True
     # false is False
     # n is False
     # no is False
     # off is False
     # 0 is False
+    # 0.0 is False
     # none is False
 
 Also, function can take ``1`` and ``0`` as integers, ``booleans`` and ``None``.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -577,6 +577,7 @@ class TestToBoolTrafaret:
         ('On', True),
         ('1', True),
         (1, True),
+        (1.0, True),
         (True, True),
         # False results
         ('false', False),
@@ -585,6 +586,7 @@ class TestToBoolTrafaret:
         ('off', False),
         ('0', False),
         (0, False),
+        (0.0, False),
         (False, False),
     ])
     def test_str_bool(self, value, expected_result):

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -386,7 +386,7 @@ class ToBool(Trafaret):
     False
     """
 
-    true_values = ('t', 'true', 'y', 'yes', 'on', '1', '1.0)
+    true_values = ('t', 'true', 'y', 'yes', 'on', '1', '1.0')
     false_values = ('false', 'n', 'no', 'off', '0', 'none', '0.0')
     convertable = true_values + false_values
 

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -386,8 +386,8 @@ class ToBool(Trafaret):
     False
     """
 
-    true_values = ('t', 'true', 'y', 'yes', 'on', '1')
-    false_values = ('false', 'n', 'no', 'off', '0', 'none')
+    true_values = ('t', 'true', 'y', 'yes', 'on', '1', '1.0)
+    false_values = ('false', 'n', 'no', 'off', '0', 'none', '0.0')
     convertable = true_values + false_values
 
     def check_and_return(self, value):
@@ -398,7 +398,7 @@ class ToBool(Trafaret):
                 value=value,
                 code=codes.IS_NOT_CONVERTIBLE_TO_BOOL,
             )
-        return _value in ('t', 'true', 'y', 'yes', 'on', '1')
+        return _value in ('t', 'true', 'y', 'yes', 'on', '1', '1.0')
 
     def __repr__(self):
         return "<ToBool>"


### PR DESCRIPTION
Reading Excel files in Pandas can result in `TRUE` turning up as `1.0`. This makes it annoying to validate with Trafaret.