### PR TITLE
Merge dicts with ignore_any attribute

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -181,6 +181,18 @@ class TestDictTrafaret:
         third.check({'bar': 4, 'bar1': 41})
         third.check({'bar': 4, 'bar1': 41, 'eggs': 'blabla'})
 
+    def test_add_kwargs_ignore_any(self):
+        first = t.Dict(
+            t.Key('bip', trafaret=t.String()), ignore_extra='*'
+        )
+        second = t.Dict(
+            t.Key('bop', trafaret=t.Int())
+        )
+
+        third = first + second
+        third.check({'bip': u'bam', 'bop': 17, 'matter': False})
+        assert third.ignore_any
+
     def test_add_kwargs_extra(self):
         first = t.Dict(
             t.Key('bar', trafaret=t.Int()), allow_extra=['eggs']

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -1123,14 +1123,14 @@ class Dict(Trafaret, DictAsyncMixin):
         Extends one Dict with other Dict Key`s or Key`s list,
         or dict instance supposed for Dict
         """
-        ignore = self.ignore
         extra = self.extras
         if isinstance(other, Dict):
             other_keys = other.keys
-            ignore += other.ignore
             extra += other.extras
+            ignore = '*' if (self.ignore_any or other.ignore_any) else self.ignore + other.ignore
         elif isinstance(other, (list, tuple)):
             other_keys = list(other)
+            ignore = self.ignore
         elif isinstance(other, dict):
             return self.__class__(other, *self.keys)
         else:


### PR DESCRIPTION
Currently, we have a behaviour:
```
>>> first = t.Dict(t.Key('string', trafaret=t.String()), ignore_extra='*')
>>> first.ignore_any
True
>>> second = t.Dict(t.Key('bop', trafaret=t.String()))
>>> second.ignore_any
False
>>> third = first + second
>>> third.ignore_any
False
>>> t.extract_error(third, {'string': 'Some string', 'bop': 'bip', 'extra_key': True})
{'extra_key': 'extra_key is not allowed key'}
```

So we do not merge correctly `Dict`s with `ignore_extra='*'`argument.

New behaviour:
```
>>> first = t.Dict(t.Key('string', trafaret=t.String()), ignore_extra='*')
>>> first.ignore_any
True
>>> second = t.Dict(t.Key('bop', trafaret=t.String()))
>>> second.ignore_any
False
>>> third = first + second
>>> third.ignore_any
True
>>> t.extract_error(third, {'string': 'Some string', 'bop': 'bip', 'extra_key': True})
{'string': 'Some string', 'bop': 'bip'}
```