### PR TITLE
Add ToEnum and Literal.

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import enum
 import pytest
 import trafaret as t
 from datetime import date, datetime

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -40,7 +40,7 @@ class TestAtomTrafaret:
         assert res == 'atom'
 
         err = extract_error(t.Atom('atom'), 'molecule')
-        assert err == "value is not exactly 'atom'"
+        assert err == "value doesn't match any variant"
 
 
 class TestBoolTrafaret:
@@ -372,9 +372,17 @@ class TestEnumTrafaret:
         res = extract_error(trafaret, 2)
         assert res == "value doesn't match any variant"
 
-    def test_repr(self):
-        trafaret = t.Enum("foo", "bar", 1)
-        assert repr(trafaret), "<Enum('foo', 'bar', 1)>"
+
+class TestToEnum:
+    def test_enum(self):
+        class MyEnum(enum.Enum):
+            foo = 3
+
+        trafaret = t.ToEnum(MyEnum)
+        assert trafaret.check(3) is MyEnum.foo
+
+        res = extract_error(trafaret, 2)
+        assert res == "not a valid value for <enum 'MyEnum'>"
 
 
 class TestToFloat:
@@ -499,6 +507,22 @@ class TestList:
         assert repr(res) == '<List(min_length=1 | <ToInt>)>'
         res = t.List[:10, t.ToInt]
         assert repr(res) == '<List(max_length=10 | <ToInt>)>'
+
+
+class TestLiteralTrafaret:
+    def test_literal(self):
+        res = t.Literal('atom').check('atom')
+        assert res == 'atom'
+
+        trafaret = t.Literal("foo", "bar", 1)
+        trafaret.check("foo")
+        trafaret.check(1)
+        res = extract_error(trafaret, 2)
+        assert res == "value doesn't match any variant"
+
+    def test_repr(self):
+        trafaret = t.Literal("foo", "bar", 1)
+        assert repr(trafaret), "<Literal('foo', 'bar', 1)>"
 
 
 class TestIterableTrafaret:

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -16,6 +16,7 @@ from .base import (
     Tuple,
 
     Atom,
+    Literal,
     Date,
     ToDate,
     DateTime,

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -76,9 +76,11 @@ __all__ = (
     "Key",
     "Dict",
     "Enum",
+    "ToEnum",
     "Tuple",
 
     "Atom",
+    "Literal",
     "String",
     "Date",
     "ToDate",

--- a/trafaret/__init__.py
+++ b/trafaret/__init__.py
@@ -13,6 +13,7 @@ from .base import (
     Key,
     Dict,
     Enum,
+    ToEnum,
     Tuple,
 
     Atom,

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import enum
 import functools
 import itertools
 import warnings
@@ -1276,6 +1277,31 @@ class Enum(Literal):
     def __init__(self, *args, **kwargs):
         deprecated("Use Literal.")
         super().__init__(*args, **kwargs)
+
+
+class ToEnum(Trafaret):
+    """
+    Converts value to an Enum instance.
+
+    >>> class MyEnum(enum.Enum):
+    ...     foo = 3
+    >>> ToEnum(MyEnum).check(3)
+    <MyEnum.foo: 3>
+    """
+    __slots__ = ["enum"]
+
+    def __init__(self, enum_: enum.Enum):
+        self.enum = enum_
+
+    def check_and_return(self, value) -> enum.Enum:
+        try:
+            return self.enum(value)
+        except ValueError:
+            self._failure(
+                "not a valid value for %s" % self.enum,
+                value=value,
+                code=codes.NOT_ENUM,
+            )
 
 
 class Callable(Trafaret):

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -438,7 +438,7 @@ class Literal(Trafaret):
     >>> Literal('atom').check('atom')
     'atom'
     >>> extract_error(Literal('atom'), 'molecule')
-    "value is not exactly 'atom'"
+    "value doesn't match any variant"
     >>> Literal('atom').is_valid('atom')
     True
     >>> Literal('atom').is_valid('molecule')

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -1300,7 +1300,7 @@ class ToEnum(Trafaret):
             self._failure(
                 "not a valid value for %s" % self.enum,
                 value=value,
-                code=codes.NOT_ENUM,
+                code=codes.NOT_MEMBER_OF_ENUM,
             )
 
 

--- a/trafaret/codes.py
+++ b/trafaret/codes.py
@@ -67,4 +67,4 @@ IS_NOT_CONVERTIBLE_TO_DATETIME = 'is_not_convertible_to_datetime'
 # Contrib
 NOT_DATETIME = 'not_datetime'
 NOT_DATE = 'not_date'
-NOT_ENUM = 'not_enum'
+NOT_MEMBER_OF_ENUM = 'not_member_of_enum'

--- a/trafaret/codes.py
+++ b/trafaret/codes.py
@@ -67,3 +67,4 @@ IS_NOT_CONVERTIBLE_TO_DATETIME = 'is_not_convertible_to_datetime'
 # Contrib
 NOT_DATETIME = 'not_datetime'
 NOT_DATE = 'not_date'
+NOT_ENUM = 'not_enum'


### PR DESCRIPTION
This adds a ToEnum class.

I'm also suggesting deprecating the existing Atom and Enum, in favour of Literal (to match the implementation of the typing module). This will also allow Enum to be repurposed for enum.Enum in the future (if desired).