### PR TITLE
Allow "null" for Null

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -537,7 +537,7 @@ class TestNullTrafaret:
         res = t.Null().check(None)
         assert res is None
         res = extract_error(t.Null(), 1)
-        assert res == 'value should be None'
+        assert res == 'value should be None/null'
 
     def test_repr(self):
         res = t.Null()
@@ -552,7 +552,7 @@ class TestOrNotToTest:
         res = null_string.check(u"test")
         assert res == u'test'
         res = extract_error(null_string, 1)
-        assert res == {0: 'value is not a string', 1: 'value should be None'}
+        assert res == {0: 'value is not a string', 1: 'value should be None/null'}
 
     def test_operator(self):
         check = t.String | t.ToInt

--- a/tests3k/test_async.py
+++ b/tests3k/test_async.py
@@ -46,7 +46,7 @@ async def test_async_or():
         await trafaret.async_check('blablabla')
     assert res.value.as_dict() == {
         0: 'value can\'t be converted to int',
-        1: 'value should be None',
+        1: 'value should be None/null',
     }
 
 async def test_async_call():

--- a/trafaret/base.py
+++ b/trafaret/base.py
@@ -350,11 +350,14 @@ class Null(Trafaret):
     True
     >>> Null().is_valid(1)
     False
+    >>> Null().is_valid("null")
+    True
     """
 
-    def check_value(self, value):
-        if value is not None:
-            self._failure("value should be None", value=value, code=codes.IS_NOT_NULL)
+    def check_and_return(self, value):
+        if value not in (None, "null"):
+            self._failure("value should be None/null", value=value, code=codes.IS_NOT_NULL)
+        return None
 
     def __repr__(self):
         return "<Null>"


### PR DESCRIPTION
Is it reasonable to allow "null" for the Null object?

Reasoning is that sometimes we're trying to operate on values passed from JS, if they've not gone through json.loads(), then we get the string value "null", rather than None. I think allowing this case, is less likely to introduce bugs in code between JS and Python.